### PR TITLE
Update coveralls.io link

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ description: A JavaScript utility library delivering consistency, modularity, pe
 
   <h2 id="features">Features</h2>
   <ul class="features-items">
-   <li>~100% <a href="https://coveralls.io/r/lodash">code coverage</a></li>
+   <li>~100% <a href="https://coveralls.io/github/lodash/lodash">code coverage</a></li>
    <li>Follows <a href="http://semver.org/">semantic versioning</a> for releases</li>
    <li><a href="http://filimanjaro.com/blog/2014/introducing-lazy-evaluation/">Lazily evaluated</a> chaining</li>
    <li><a href="/docs#_">_(…)</a> supports implicit chaining</li>


### PR DESCRIPTION
The previous link 403'ed.

N.b. The homepage of coveralls.io links to `https://coveralls.io/r/lodash/lodash`, which in turn redirects to the added link (`https://coveralls.io/github/lodash/lodash`). Figured it was a bit faster and perhaps the `/r/` link may change again?
